### PR TITLE
fix: Make signature of LazyTextFile constructor adhere to its parent class

### DIFF
--- a/src/projen/lazy-textfile.ts
+++ b/src/projen/lazy-textfile.ts
@@ -1,5 +1,4 @@
-import { IConstruct } from 'constructs';
-import { FileBase, FileBaseOptions, IResolver, TextFile } from 'projen';
+import { FileBase, FileBaseOptions, IResolver, Project, TextFile } from 'projen';
 
 export interface LazyTextFileOptions extends FileBaseOptions {
   /**
@@ -19,8 +18,8 @@ export class LazyTextFile extends TextFile {
    * @param filePath File path
    * @param options Options
    */
-  constructor(scope: IConstruct, filePath: string, options?: LazyTextFileOptions) {
-    super(scope, filePath, options);
+  constructor(project: Project, filePath: string, options?: LazyTextFileOptions) {
+    super(project, filePath, options);
     this.content = options?.content ?? (() => '');
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix the constructor signature of the LazyTextFile class which should accept a parameter of type Project but was set to take a Construct instead

* **What is the current behavior?** (You can also link to an open issue here)

Wrong type signature on LazyTextFile class.

* **What is the new behavior (if this is a feature change)?**

This change should introduce no change to runtime behavior due to type erasure during compilation

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

Nope

* **Other information**:

Small oversight when accepting the previous PR