### PR TITLE
fix: Generate RestAPI class in correct path within project directory

### DIFF
--- a/src/projen/rest-api.ts
+++ b/src/projen/rest-api.ts
@@ -64,7 +64,7 @@ export class RestApi extends pj.Component {
       fileGenerator: this.generateSampleHandlerFiles.bind(this),
     });
 
-    const apiFile = new pj.TextFile(this.project, `${this.project.outdir}/src/generated/rest.${this.options.apiName.toLowerCase()}-api.generated.ts`);
+    const apiFile = new pj.TextFile(this.project, `src/generated/rest.${this.options.apiName.toLowerCase()}-api.generated.ts`);
     apiFile.addLine(this.createConstructFile(apiFile));
 
   }

--- a/test/util/synth.ts
+++ b/test/util/synth.ts
@@ -3,9 +3,14 @@ import * as path from 'node:path';
 import * as yaml from 'js-yaml';
 import { Project } from 'projen';
 
-export function createOpenApiDefinitionFile(project: Project, obj: any): string {
+interface OpenApiDefinitionSnapshot {
+  definitionFile: string;
+  content: string;
+}
+
+export function createOpenApiDefinitionFile(project: Project, obj: any, filename?: string): OpenApiDefinitionSnapshot {
   const spec = yaml.dump(obj);
-  const outputFileName = 'valid-ref.yaml';
+  const outputFileName = filename ?? 'openapi.yaml';
   fs.writeFileSync(path.join(project.outdir, outputFileName), spec);
-  return outputFileName;
+  return { definitionFile: outputFileName, content: spec };
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Generates the RestAPI class for a generated Rest API within the correct path.

* **What is the current behavior?** (You can also link to an open issue here)

Generated RestAPI class file (`rest.$RESTAPINAM-api.generated.ts`) is accidentally placed in `$projectdir/absolue/path/to/project/src/generated`.

* **What is the new behavior (if this is a feature change)?**

File will be placed within the project dir again

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

Only insofar as that it fixes behavior that was broken before
