### PR TITLE
fix: exempt CORS OPTIONS from authorizer (closes #372)

### DIFF
--- a/src/constructs/rest-api.ts
+++ b/src/constructs/rest-api.ts
@@ -248,6 +248,7 @@ export class RestApi<PATHS, OPS> extends BaseApi {
           'summary': 'CORS support',
           'description': 'Enable CORS by returning correct headers',
           'tags': ['CORS'],
+          'security': [],
           'responses': {
             200: {
               description: 'Default response for CORS method',


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @hoegertn :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Fixes the CORS preflight failure when `RestApi` is configured with both `cors: true` and an `authentication` provider.

**Root cause:** The generated CORS `OPTIONS` operation at `/{proxy+}` had no explicit `security` field, so `patchSecurity` applied the global authorizer requirement to it. Browsers never send credentials on preflight requests, causing a `401` before the mock integration could return CORS headers.

**Fix:** Set `security: []` on the CORS OPTIONS operation definition so the global requirement is overridden and preflight remains unauthenticated.

## Changes

- `src/constructs/rest-api.ts`: Added `'security': []` to the CORS OPTIONS operation object

## Testing

- All 41 existing tests pass
- ESLint clean
- TypeScript compiles without errors
- The `patchSecurity` method already has logic to preserve explicit `security` on an operation (the `else` branch at "Operation already has explicit security defined in the spec"), so the empty array is never overwritten

Closes #372